### PR TITLE
Properly format publishing date

### DIFF
--- a/_layouts/articles.html
+++ b/_layouts/articles.html
@@ -15,7 +15,7 @@
           <div class="col-md-offset-1 col-md-11">
             <article>
               <h1>{{page.title}}</h1>
-              <div class="blog-post-meta">Published on <time pubdate class="timeago" datetime="{{page.date | date:"%FT%TZ"}}">{{ page.date | date_to_string }}</time></div>
+              <div class="blog-post-meta">Published <time pubdate class="timeago" datetime="{{page.date | date:"%FT%TZ"}}">{{ page.date | date_to_string }}</time></div>
               <div class=row>
                 <div class="col-md-10">
                   {{ content }}


### PR DESCRIPTION
The "on" should probably not be there in "Published x days ago".

I really enjoyed your article "On writing", 
and thanks for your contribution to GoReleaser!


One more thing, for me the articles become easier to read when changing the width from `col-md-10` down to `col-md-8`.